### PR TITLE
update asm and shade plugin for java8

### DIFF
--- a/japi-checker-cli/dependency-reduced-pom.xml
+++ b/japi-checker-cli/dependency-reduced-pom.xml
@@ -33,7 +33,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.0</version>
+        <version>2.4.1</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/japi-checker-cli/pom.xml
+++ b/japi-checker-cli/pom.xml
@@ -86,7 +86,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.0</version>
+				<version>2.4.1</version>
 				<executions>
 					<execution>
 						<phase>package</phase>

--- a/japi-checker/pom.xml
+++ b/japi-checker/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
-            <version>4.0</version>
+            <version>5.0.4</version>
 			<type>jar</type>
 			<scope>compile</scope>
         </dependency>


### PR DESCRIPTION
I was seeing errors when using with classes compiled for java8 bytecode:

```
Exception in thread "main" java.lang.IllegalArgumentException
    at org.objectweb.asm.ClassReader.<init>(Unknown Source)
    at org.objectweb.asm.ClassReader.<init>(Unknown Source)
    at com.googlecode.japi.checker.JarReader.read(JarReader.java:70)
    at com.googlecode.japi.checker.DefaultClassDataLoader.read(DefaultClassDataLoader.java:55)
    at com.googlecode.japi.checker.DefaultClassDataLoader.read(DefaultClassDataLoader.java:116)
    at com.googlecode.japi.checker.cli.Main.run(Main.java:100)
    at com.googlecode.japi.checker.cli.Main.main(Main.java:47)
```

Updating the asm and shade versions seems to clear it up.
